### PR TITLE
fix permissions to run ./gradlew

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ build:
   stage: build
   script:
   - yarn
-  - cd android && ./gradlew assembleDebug
+  - cd android
+  - chmod +x ./gradlew
+  - ./gradlew assembleDebug
   artifacts:
     paths:
     - android/app/build/outputs/apk/


### PR DESCRIPTION
when I run this code, i receive this error mesage:

> /bin/bash: line 67: ./gradlew: Permission denied

to fix this I reuse the [solution used in the react-native-share ci](https://github.com/react-native-community/react-native-share/commit/5c20929d8fb51fbe08a2bef7d39fd5cb985f39aa#diff-29944324a3cbf9f4bd0162dfe3975d88)