### PR TITLE
Add locale, and change nodejs to a LTS version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,13 +38,13 @@ RUN curl -s https://dl.google.com/android/repository/sdk-tools-linux-${VERSION_S
     rm -v /sdk.zip
 
 RUN mkdir -p $ANDROID_HOME/licenses/ \
-  && echo "8933bad161af4178b1185d1a37fbf41ea5269c55\nd56f5187479451eabf01fb78af6dfcb131a6481e" > $ANDROID_HOME/licenses/android-sdk-license \
+  && echo "8933bad161af4178b1185d1a37fbf41ea5269c55\nd56f5187479451eabf01fb78af6dfcb131a6481e\n24333f8a63b6825ea9c5514f83c2829b004d1fee" > $ANDROID_HOME/licenses/android-sdk-license \
   && echo "84831b9409646a918e30573bab4c9c91346d8abd" > $ANDROID_HOME/licenses/android-sdk-preview-license
 
 ADD packages.txt /sdk
 RUN mkdir -p /root/.android && \
   touch /root/.android/repositories.cfg && \
-  ${ANDROID_HOME}/tools/bin/sdkmanager --update 
+  ${ANDROID_HOME}/tools/bin/sdkmanager --update
 
 RUN while read -r package; do PACKAGES="${PACKAGES}${package} "; done < /sdk/packages.txt && \
     ${ANDROID_HOME}/tools/bin/sdkmanager ${PACKAGES}
@@ -61,7 +61,7 @@ RUN echo "Installing Additional Libraries" \
 	 && rm -rf /var/lib/gems \
 	 && apt-get update && apt-get install $BUILD_PACKAGES -qqy --no-install-recommends \
 	 && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-	 
+
 RUN echo "Change locale" \
 	&& localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,12 +54,18 @@ RUN echo "Installing Yarn Deb Source" \
 	&& echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
 RUN echo "Installing Node.JS" \
-	&& curl -sL https://deb.nodesource.com/setup_9.x | bash -
+	&& curl -sL https://deb.nodesource.com/setup_10.x | bash -
 
-ENV BUILD_PACKAGES git yarn nodejs build-essential imagemagick librsvg2-bin ruby ruby-dev wget libcurl4-openssl-dev
+ENV BUILD_PACKAGES git yarn nodejs build-essential imagemagick librsvg2-bin ruby ruby-dev wget libcurl4-openssl-dev locales
 RUN echo "Installing Additional Libraries" \
 	 && rm -rf /var/lib/gems \
-	 && apt-get update && apt-get install $BUILD_PACKAGES -qqy --no-install-recommends
+	 && apt-get update && apt-get install $BUILD_PACKAGES -qqy --no-install-recommends \
+	 && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+	 
+RUN echo "Change locale" \
+	&& localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG en_US.UTF-8
 
 RUN echo "Installing Fastlane 2.61.0" \
 	&& gem install fastlane badge -N \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # gitlab-ci-react-native-android
-## Android 26.0.1 and Fastlane 2.61.0 
+## Android 28.0.3 and Fastlane 2.61.0 
 This Docker image contains react-native and the Android SDK and most common packages necessary for building Android apps in a CI tool like GitLab CI. 
 
 A `.gitlab-ci.yml` with caching of your project's dependencies would look like this:
@@ -38,3 +38,14 @@ or run from remote
 	docker stop 3c854ac65f64d424c097e639c002b50431454e839b5c551ec2a929dcbecb7176
 	
 ````
+
+## How to upgrade tool version
+If you want to upgrade version of android sdk or build tools, please follow following staps.
+
+1. Edit pacakges.txt to update version or add a new package
+2. Run `$ANDROID_HOME/bin/sdkmanager "<package;version>"` in your local machine, then to check the file `$ANDROID_HOME/licenses/android-sdk-license`  
+Ensure that all lines of the file in your local machine are included by Ln42 in `Dockerfile` just like following:
+```
+  && echo "8933bad161af4178b1185d1a37fbf41ea5269c55\nd56f5187479451eabf01fb78af6dfcb131a6481e\n24333f8a63b6825ea9c5514f83c2829b004d1fee" > $ANDROID_HOME/licenses/android-sdk-license \
+```
+3. Build the docker and publish it.

--- a/packages.txt
+++ b/packages.txt
@@ -1,5 +1,6 @@
 add-ons;addon-google_apis-google-24
 build-tools;26.0.2
+build-tools;27.0.3
 build-tools;28.0.3
 extras;android;m2repository
 extras;google;m2repository

--- a/packages.txt
+++ b/packages.txt
@@ -1,5 +1,6 @@
 add-ons;addon-google_apis-google-24
 build-tools;26.0.2
+build-tools;28.0.3
 extras;android;m2repository
 extras;google;m2repository
 extras;google;google_play_services
@@ -7,3 +8,4 @@ extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2
 extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2
 platform-tools
 platforms;android-26
+platforms;android-27


### PR DESCRIPTION
1. Set locale to UTF-8 to allow build projects that contains some unicode string, e.g. Chinese 
2. Update NodeJS to version v10 which is a LTS version. Some libraries (e.g. ReactNative 0.57.4) is incompatible with NodeJS 9.